### PR TITLE
Check "component" postfix at derived-class-names

### DIFF
--- a/lib/rules/derived-class-names.js
+++ b/lib/rules/derived-class-names.js
@@ -32,7 +32,7 @@ module.exports = {
                     : capitalize(postfix));
             const actualClassName = node.id.name;
 
-            if (expectedClassName !== actualClassName) {
+            if ((postfix.toLowerCase() !== 'component') && (expectedClassName !== actualClassName)) {
                 const { id: { loc } } = node;
                 context.report({
                     loc,


### PR DESCRIPTION
Make derived-class-names rule to work as documented at https://github.com/scandipwa/eslint/blob/master/docs/rules/derived-class-names.md